### PR TITLE
feat: Service WorkerによるPOSTベースGIF変換API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .claude/settings.local.json
+.playwright-mcp/

--- a/converter.js
+++ b/converter.js
@@ -1,0 +1,117 @@
+// V2GIF Converter - FFmpeg.wasmによる動画→GIF変換モジュール
+
+class V2GIFConverter {
+  constructor() {
+    this.ffmpeg = null;
+    this.ffmpegError = null;
+    this.onLog = null;
+    this.onProgress = null;
+  }
+
+  async init() {
+    const { createFFmpeg } = FFmpeg;
+
+    this.ffmpeg = createFFmpeg({
+      mainName: 'main',
+      corePath: 'https://unpkg.com/@ffmpeg/core-st@0.11.1/dist/ffmpeg-core.js',
+      log: true
+    });
+
+    this.ffmpeg.setLogger(({ type, message }) => {
+      if (message) {
+        if (this.onLog) this.onLog(message);
+        if (message.includes('Out of memory') ||
+            message.includes('Error while filtering') ||
+            message.includes('Conversion failed') ||
+            message.includes('failed to execute')) {
+          this.ffmpegError = message;
+        }
+      }
+    });
+
+    this.ffmpeg.setProgress(({ ratio }) => {
+      if (this.onProgress) this.onProgress(ratio);
+    });
+
+    await this.ffmpeg.load();
+  }
+
+  async convert(videoData, params = {}) {
+    await this.init();
+    this.ffmpegError = null;
+
+    try {
+      const fps = params.fps || '10';
+      const width = params.width || '600';
+      const height = params.height || '-1';
+      const startTime = parseFloat(params.startTime) || 0;
+      const endTime = params.endTime ? parseFloat(params.endTime) : null;
+      const scale = `${width}:${height}`;
+
+      // 入力ファイル書き込み
+      this.ffmpeg.FS('writeFile', 'input.mp4', new Uint8Array(videoData));
+
+      // FFmpegコマンド構築
+      const ffmpegArgs = [];
+
+      if (startTime > 0) {
+        ffmpegArgs.push('-ss', startTime.toString());
+      }
+
+      ffmpegArgs.push('-i', 'input.mp4');
+
+      if (endTime !== null && endTime > startTime) {
+        ffmpegArgs.push('-t', (endTime - startTime).toString());
+      }
+
+      // 切り出しフィルター
+      let cropFilter = '';
+      if (params.cropX != null && params.cropY != null && params.cropWidth && params.cropHeight) {
+        cropFilter = `crop=${params.cropWidth}:${params.cropHeight}:${params.cropX}:${params.cropY},`;
+      }
+
+      ffmpegArgs.push(
+        '-filter_complex',
+        `[0:v]${cropFilter}fps=${fps},scale=${scale}:flags=lanczos,split[s0][s1];` +
+        `[s0]palettegen[p];` +
+        `[s1][p]paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle`,
+        '-y', 'output.gif'
+      );
+
+      await this.ffmpeg.run(...ffmpegArgs);
+
+      if (this.ffmpegError) {
+        throw new Error(this.ffmpegError);
+      }
+
+      // 出力チェック
+      const files = this.ffmpeg.FS('readdir', '/');
+      if (!files.includes('output.gif')) {
+        throw new Error('GIF file was not created');
+      }
+
+      const outputStat = this.ffmpeg.FS('stat', '/output.gif');
+      if (outputStat.size === 0) {
+        throw new Error('GIF file is empty');
+      }
+
+      // 結果読み込み
+      const data = this.ffmpeg.FS('readFile', 'output.gif');
+      const gifBlob = new Blob([data.buffer], { type: 'image/gif' });
+
+      return gifBlob;
+
+    } finally {
+      // クリーンアップ
+      try {
+        this.ffmpeg.FS('unlink', 'input.mp4');
+        this.ffmpeg.FS('unlink', 'output.gif');
+      } catch (e) { /* ignore */ }
+
+      if (this.ffmpeg && this.ffmpeg.isLoaded()) {
+        this.ffmpeg.exit();
+        this.ffmpeg = null;
+      }
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -775,6 +775,7 @@
 
     <!-- FFmpeg.wasm CDN（シングルスレッド版 - バージョン統一） -->
     <script src="https://unpkg.com/@ffmpeg/ffmpeg@0.11.1/dist/ffmpeg.min.js"></script>
+    <script src="converter.js"></script>
     <script>
         (async () => {
             const { createFFmpeg, fetchFile } = FFmpeg;
@@ -1725,6 +1726,30 @@
                 updateSizeMode();
             });
         })();
+
+        // Service Worker登録 & API メッセージハンドラ
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('sw.js').then((reg) => {
+                console.log('V2GIF Service Worker registered:', reg.scope);
+            }).catch((err) => {
+                console.error('Service Worker registration failed:', err);
+            });
+
+            // Service Workerからの変換リクエストを処理
+            navigator.serviceWorker.addEventListener('message', async (event) => {
+                if (event.data.type !== 'v2gif-convert') return;
+
+                const port = event.ports[0];
+                try {
+                    const converter = new V2GIFConverter();
+                    converter.onLog = (msg) => console.log('[API]', msg);
+                    const gif = await converter.convert(event.data.video, event.data.params);
+                    port.postMessage({ gif });
+                } catch (error) {
+                    port.postMessage({ error: error.message });
+                }
+            });
+        }
     </script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,92 @@
+// V2GIF Service Worker
+// POST /convert をインターセプトし、クライアントページのFFmpeg.wasmで変換してGIFを返す
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+
+  if (event.request.method === 'POST' && url.pathname.endsWith('/convert')) {
+    event.respondWith(handleConvert(event.request));
+  }
+});
+
+async function handleConvert(request) {
+  try {
+    const formData = await request.formData();
+    const video = formData.get('video');
+
+    if (!video) {
+      return jsonResponse(400, { error: 'video field is required' });
+    }
+
+    const params = {
+      fps: formData.get('fps') || '10',
+      width: formData.get('width') || '600',
+      height: formData.get('height') || '-1',
+      startTime: formData.get('startTime') || '0',
+      endTime: formData.get('endTime') || null,
+      cropX: formData.get('cropX') || null,
+      cropY: formData.get('cropY') || null,
+      cropWidth: formData.get('cropWidth') || null,
+      cropHeight: formData.get('cropHeight') || null,
+    };
+
+    const videoBuffer = await video.arrayBuffer();
+
+    // アクティブなV2GIFページを探す
+    const allClients = await self.clients.matchAll({ type: 'window' });
+
+    if (allClients.length === 0) {
+      return jsonResponse(503, {
+        error: 'No active V2GIF page. Please open the V2GIF page in a browser tab first.'
+      });
+    }
+
+    // MessageChannelでページに処理を委譲し、結果を待つ
+    const client = allClients[0];
+    const messageChannel = new MessageChannel();
+
+    return new Promise((resolve) => {
+      const timeout = setTimeout(() => {
+        resolve(jsonResponse(504, { error: 'Conversion timed out' }));
+      }, 300000); // 5分タイムアウト
+
+      messageChannel.port1.onmessage = (event) => {
+        clearTimeout(timeout);
+        if (event.data.error) {
+          resolve(jsonResponse(500, { error: event.data.error }));
+        } else {
+          resolve(new Response(event.data.gif, {
+            status: 200,
+            headers: {
+              'Content-Type': 'image/gif',
+              'Content-Disposition': 'attachment; filename="output.gif"'
+            }
+          }));
+        }
+      };
+
+      client.postMessage(
+        { type: 'v2gif-convert', video: videoBuffer, params },
+        [messageChannel.port2, videoBuffer]
+      );
+    });
+
+  } catch (error) {
+    return jsonResponse(500, { error: error.message });
+  }
+}
+
+function jsonResponse(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}


### PR DESCRIPTION
## Summary
- `POST /convert` に動画ファイルとパラメータを送信するとGIFアニメを返すAPIを実装
- Service Workerがリクエストをインターセプトし、ページ上のFFmpeg.wasmで変換処理を実行
- 変換ロジックを `converter.js` に分離し、UI・API両方から利用可能に

## パラメータ
| パラメータ | 説明 | デフォルト |
|---|---|---|
| `video` (必須) | 動画ファイル | - |
| `fps` | フレームレート | 10 |
| `width` | 幅 | 600 |
| `height` | 高さ | -1 (自動) |
| `startTime` | 開始時間(秒) | 0 |
| `endTime` | 終了時間(秒) | null (最後まで) |
| `cropX/Y/Width/Height` | 切り出し範囲 | null |

## Test plan
- [x] ローカルサーバーで `POST /convert` にテスト動画を送信し、GIFが返ることを確認済み
- [x] レスポンスの Content-Type が `image/gif` であることを確認済み
- [ ] GitHub Pagesデプロイ後の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)